### PR TITLE
Add Crew and Action pages

### DIFF
--- a/content/actions/_index.md
+++ b/content/actions/_index.md
@@ -1,0 +1,33 @@
+---
+title: Actions
+weight: 100
+
+---
+
+Actions in _Mobile Suits in the Black_ are the same as those in _Scum and
+Villainy_, but it's worth a spending a few words on which actions you may want
+to roll while piloting a vehicle since so much time will be spent in them (and
+most characters, not just people playing the Pilot playbook, will be doing so).
+
+It's not a bad idea to consider taking the Stardancer crew's special ability
+**Problem Solvers** to make sure everyone on your crew has a chance to have at
+least one dot in **Helm**, which will probably be one of the more important
+actions for a mobile suit team.
+
+## Helm
+
+**Helm** is still your go-to for piloting your mobile suit. Nothing to say here
+really.
+
+## Skulk
+
+**Skulk** could be used in an MS if you were trying to get around quietly. When
+I'm playing _Blades_ or _Scum_, I think of Skulk as your character's aptitude
+and instinct for getting around quietly.
+
+The scene in _Gundam Seed_ where the [GAT-X207 Blitz
+Gundam](http://gundam.wikia.com/wiki/GAT-X207_Blitz_Gundam) uses its camouflage
+technology to get inside the defensive perimeter of the Federation's Artemis
+base very much feels like Skulk. Same for the scene where Kamille and Quattro
+infiltrate Kilimanjaro in their [Hyaku
+Shiki](http://gundam.wikia.com/wiki/MSN-00100_Hyaku_Shiki) and [Zeta Gundam](http://gundam.wikia.com/wiki/MSZ-006_Zeta_Gundam).

--- a/content/mobile-suits/_index.md
+++ b/content/mobile-suits/_index.md
@@ -1,7 +1,7 @@
 ---
 alwaysopen: "true"
 title: Mobile Suits
-weight: "400"
+weight: "600"
 ---
 
 Mobile Suits are giant, usually humanoid, robotic warmachines, and the most

--- a/content/mobile-suits/rgm-79-gm.md
+++ b/content/mobile-suits/rgm-79-gm.md
@@ -1,0 +1,30 @@
+---
+title: RGM-79 GM
+type: mobile-suit
+msName: "GM (Jimu)"
+modelNumber: "RGM-79"
+secondaryModelNumbers:
+gundamWikiLink: "http://gundam.wikia.com/wiki/RGM-79_GM"
+imageURL: "https://vignette.wikia.nocookie.net/gundam/images/7/7d/Rgm-79.jpg"
+msClass: mass-production
+mobileSuitSystems:
+  starting:
+    engines: 0
+    comms: 1
+    hull: 2
+    weapons: 1
+  maximum:
+    engines: 1
+    comms: 1
+    hull: 2
+    weapons: 3
+specialMoves:
+- name: Titanium  Armor
+  description: |
+    The GM's greatest advantage is the strength and lightness of its armor. You
+    can spend your GM's special armor to completely resist the damage from a
+    beam attack. You also have potency when speed matters while facing another
+    mobile suit of the same class.
+
+---
+

--- a/content/playbooks/_index.md
+++ b/content/playbooks/_index.md
@@ -1,7 +1,7 @@
 ---
 alwaysopen: "true"
 title: Playbooks
-weight: "300"
+weight: "400"
 ---
 
 The playbooks offered here are what I imagine makes sense for a game set in the

--- a/content/ships-and-crew/_index.md
+++ b/content/ships-and-crew/_index.md
@@ -1,0 +1,13 @@
+---
+title: Ships and Crew
+weight: 300
+
+---
+
+Use the crews from _Scum and Villainy_. There is, however, one major change that
+_Mobile Suits in the Black_ makes: all crews **start** with the **Personal
+vehicles** upgrade from the **Cerberus** crew.
+
+Additionally, the **Stardancer**'s **Problem Solvers** special ability is not
+considered a veteran crew advance. It's important that all characters have
+access to the **Helm** action more freely.

--- a/layouts/mobile-suit/single.html
+++ b/layouts/mobile-suit/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   <h5>{{ .Params.modelNumber }} {{ .Params.msName }}</h5>
-  Class: {{ .Params.msClass | title }} | <em><a href="{{ .Params.gundamWikiLink }}">See this mobile suit on the Gundam Wiki</a></em>
+  Class: {{ .Params.msClass | title }} | <em><a rel="noopener noreferrer nofollow" href="{{ .Params.gundamWikiLink }}">See this mobile suit on the Gundam Wiki</a></em>
 
   <div class="ms-portrait">
     <img src="{{ .Params.imageURL }}" alt="a picture of the {{ .Title }} mobile suit"/>

--- a/layouts/mobile-suit/single.html
+++ b/layouts/mobile-suit/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   <h5>{{ .Params.modelNumber }} {{ .Params.msName }}</h5>
-  Class: {{ .Params.msClass | title }} | <em><a rel="noopener noreferrer nofollow" href="{{ .Params.gundamWikiLink }}">See this mobile suit on the Gundam Wiki</a></em>
+  Class: {{ .Params.msClass | title }} | <em><a rel="noopener noreferrer nofollow" target="_blank" href="{{ .Params.gundamWikiLink }}">See this mobile suit on the Gundam Wiki</a></em>
 
   <div class="ms-portrait">
     <img src="{{ .Params.imageURL }}" alt="a picture of the {{ .Title }} mobile suit"/>


### PR DESCRIPTION
Add:

- crew
- actions
- empty footer to clear the 'add a footer' stuff
- fix relationship and link behavior when linking to Gundam wiki