### PR TITLE
Publish GM, Qubeley, Commander, template fixes

### DIFF
--- a/archetypes/playbook.md
+++ b/archetypes/playbook.md
@@ -3,5 +3,14 @@ title: {{ replace .Name "-" " " | title }}
 type: playbook
 playbookDescription: A description in a few words
 reasonToPlay: play as a PLAYBOOK_SUMMARY, like EXAMPLES FROM MSG
+startingActionDots:
+- action_1: 2
+- action_2: 1
+startingMove:
+  name: NAME
+  description: DESCRIPTION
+specialMoves:
+- name: NAME
+  description: DESCRIPTION
 
 ---

--- a/archetypes/playbook.md
+++ b/archetypes/playbook.md
@@ -4,8 +4,10 @@ type: playbook
 playbookDescription: A description in a few words
 reasonToPlay: play as a PLAYBOOK_SUMMARY, like EXAMPLES FROM MSG
 startingActionDots:
-- action_1: 2
-- action_2: 1
+- action: ACTION_NAME
+  dots: 2
+- action: ACTION_NAME
+  dots: 
 startingMove:
   name: NAME
   description: DESCRIPTION

--- a/content/_index.md
+++ b/content/_index.md
@@ -15,13 +15,12 @@ _MSitB_ makes the following changes to _SaV_:
 
 - changes for characters
   - adds some playbooks, and makes some suggestions about which _SaV_ playbooks
-    will work well with the new ones
+    will work well with the new ones (pending)
   - provides some Veteran Advance movesets for discovering your character's
     latent Newtype abilities, or for expressing the powers awakened in them when
-    they were made into a Cyber Newtype
+    they were made into a Cyber Newtype (pending)
   - provides some new backgrounds and heritages
 - provides some guidelines for creating mobile suits from the Mobile Suit Gundam
   series' as personal vehicles
-- provides a new ship type, the **Mobile Suit Carrier**
-- provides a faction list for the Earth Sphere during the early UC
+- provides a faction list for the Earth Sphere during the early UC (pending)
 

--- a/content/actions/_index.md
+++ b/content/actions/_index.md
@@ -1,0 +1,33 @@
+---
+title: Actions
+weight: 100
+
+---
+
+Actions in _Mobile Suits in the Black_ are the same as those in _Scum and
+Villainy_, but it's worth a spending a few words on which actions you may want
+to roll while piloting a vehicle since so much time will be spent in them (and
+most characters, not just people playing the Pilot playbook, will be doing so).
+
+It's not a bad idea to consider taking the Stardancer crew's special ability
+**Problem Solvers** to make sure everyone on your crew has a chance to have at
+least one dot in **Helm**, which will probably be one of the more important
+actions for a mobile suit team.
+
+## Helm
+
+**Helm** is still your go-to for piloting your mobile suit. Nothing to say here
+really.
+
+## Skulk
+
+**Skulk** could be used in an MS if you were trying to get around quietly. When
+I'm playing _Blades_ or _Scum_, I think of Skulk as your character's aptitude
+and instinct for getting around quietly.
+
+The scene in _Gundam Seed_ where the [GAT-X207 Blitz
+Gundam](http://gundam.wikia.com/wiki/GAT-X207_Blitz_Gundam) uses its camouflage
+technology to get inside the defensive perimeter of the Federation's Artemis
+base very much feels like Skulk. Same for the scene where Kamille and Quattro
+infiltrate Kilimanjaro in their [Hyaku
+Shiki](http://gundam.wikia.com/wiki/MSN-00100_Hyaku_Shiki) and [Zeta Gundam](http://gundam.wikia.com/wiki/MSZ-006_Zeta_Gundam).

--- a/content/mobile-suits/_index.md
+++ b/content/mobile-suits/_index.md
@@ -1,7 +1,7 @@
 ---
 alwaysopen: "true"
 title: Mobile Suits
-weight: "400"
+weight: "600"
 ---
 
 Mobile Suits are giant, usually humanoid, robotic warmachines, and the most

--- a/content/mobile-suits/amx-004-qubeley.md
+++ b/content/mobile-suits/amx-004-qubeley.md
@@ -32,3 +32,5 @@ specialMoves:
     - create a field of beam-cannon fire to slow a pursuer down
 
 ---
+
+This mobile suit is a unique/ace suit in Zeta, but pretty quickly becomes a performance model by the end of ZZ.

--- a/content/mobile-suits/amx-004-qubeley.md
+++ b/content/mobile-suits/amx-004-qubeley.md
@@ -1,0 +1,34 @@
+---
+title: AMX 004 Quebeley
+type: mobile-suit
+msName: "Qubeley"
+modelNumber: "AMX-004"
+secondaryModelNumbers:
+gundamWikiLink: "http://gundam.wikia.com/wiki/AMX-004_Qubeley"
+imageURL: "https://vignette.wikia.nocookie.net/gundam/images/5/53/Amx-004.jpg"
+msClass:  unique-ace
+mobileSuitSystems:
+  starting:
+    engines: 1
+    comms: 3
+    hull: 2
+    weapons: 2
+  maximum:
+    engines: 2
+    comms: 4
+    hull: 3
+    weapons: 4
+specialMoves:
+- name: Funnels
+  description: |
+    Any mobile suit equipped with a **psychoframe** that you sortie in can
+    deploy **funnels** or **bits**, which are small remote-controlled
+    beam-cannons capable of moving themselves around in space at your mental
+    command. You can spend Stress, one for one, for any of the following
+    effects:
+
+    - attack an enemy from a direction they're not expecting
+    - attack multiple enemies simultaneously
+    - create a field of beam-cannon fire to slow a pursuer down
+
+---

--- a/content/mobile-suits/rgm-79-gm.md
+++ b/content/mobile-suits/rgm-79-gm.md
@@ -1,0 +1,30 @@
+---
+title: RGM-79 GM
+type: mobile-suit
+msName: "GM (Jimu)"
+modelNumber: "RGM-79"
+secondaryModelNumbers:
+gundamWikiLink: "http://gundam.wikia.com/wiki/RGM-79_GM"
+imageURL: "https://vignette.wikia.nocookie.net/gundam/images/7/7d/Rgm-79.jpg"
+msClass: mass-production
+mobileSuitSystems:
+  starting:
+    engines: 0
+    comms: 1
+    hull: 2
+    weapons: 1
+  maximum:
+    engines: 1
+    comms: 1
+    hull: 2
+    weapons: 3
+specialMoves:
+- name: Titanium  Armor
+  description: |
+    The GM's greatest advantage is the strength and lightness of its armor. You
+    can spend your GM's special armor to completely resist the damage from a
+    beam attack. You also have potency when speed matters while facing another
+    mobile suit of the same class.
+
+---
+

--- a/content/playbooks/_index.md
+++ b/content/playbooks/_index.md
@@ -1,7 +1,7 @@
 ---
 alwaysopen: "true"
 title: Playbooks
-weight: "300"
+weight: "400"
 ---
 
 The playbooks offered here are what I imagine makes sense for a game set in the

--- a/content/playbooks/commander.md
+++ b/content/playbooks/commander.md
@@ -30,3 +30,10 @@ specialMoves:
     stress for failed rolls when leading a group action.
 
 ---
+
+development watchwords:
+
+- insightful
+- blooded
+- remorseless
+- lost

--- a/content/playbooks/commander.md
+++ b/content/playbooks/commander.md
@@ -1,0 +1,32 @@
+---
+title: Commander
+type: playbook
+playbookDescription: A commander, who specializes in leading and supporting their team.
+reasonToPlay: play as an experienced commander or leader, like Bright Noa, or Shiro Amada from _08 MS Team_.
+startingActionDots:
+- action: command
+  dots: 2
+- action: study
+  dots: 1
+startingMove:
+  name: Hard choices
+  description: |
+    Before the start of a mission, you have to make a call. If
+    you have the crew attack just there, or at just that time, you'll have an
+    edge. Your crew has potency on their actions as long as they follow your
+    directives for the mission. But there's a cost... there's always a cost.
+    Choose one:
+
+    - Harm that your crew takes during this mission is 1 level higher than it
+        would normally be, because you've put them directly in the line of fire.
+    - The GM starts a 6-clock, which they will fill as the mission proceeds
+        (most likely on failed rolls). When it is full, the enemy's elite
+        reinforcements arrive. They outclass you, even with your tactical
+        edge.
+specialMoves:
+- name: Shrewd Commander
+  description: |
+    You gain potency when you lead a group action. Additionally, suffer 1 less
+    stress for failed rolls when leading a group action.
+
+---

--- a/content/playbooks/mechanic.md
+++ b/content/playbooks/mechanic.md
@@ -1,8 +1,0 @@
----
-playbookDescription: A capable pilot and mechanic, the person who keeps the team running
-reasonToPlay: be a great mechanic and a capable pilot, and central to your team's
-  operation, like Karen Joshua in 08 MS Team, or Astonaige in Zeta and Char's Counterattack.
-title: Mechanic
-type: playbook
----
-

--- a/content/playbooks/newtype.md
+++ b/content/playbooks/newtype.md
@@ -4,6 +4,9 @@ type: playbook
 playbookDescription: An accomplished Newtype, beginning to push the edge of their
   abilities.
 reasonToPlay: play as a seasoned Newtype, like Char or Amuro from Zeta or later.
+startingActionDots:
+- attune: 2
+- helm: 1
 specialMoves:
 - name: Entangled Minds
   description: |

--- a/content/playbooks/newtype.md
+++ b/content/playbooks/newtype.md
@@ -16,17 +16,6 @@ specialMoves:
     that door, or around that asteroid. They, of course, sense the your pressure
     on their psyche as well. When acting on this information your position and
     effect are either Desperate-Great, or Controlled-Limited.
-- name: Funnels
-  description: |
-    Any mobile suit equipped with a **psychoframe** that you sortie in can
-    deploy **funnels** or **bits**, which are small remote-controlled
-    beam-cannons capable of moving themselves around in space at your mental
-    command. You can spend Stress, one for one, for any of the following
-    effects:
-
-    - attack an enemy from a direction they're not expecting
-    - attack multiple enemies simultaneously
-    - create a field of beam-cannon fire to slow a pursuer down
 - name: Human Understanding
   description: |
     You can push yourself to meet a friend or foe, for a moment uninterrupted,

--- a/content/playbooks/rookie.md
+++ b/content/playbooks/rookie.md
@@ -25,3 +25,9 @@ startingMove:
 
 ---
 
+development watchwords:
+
+- adaptable
+- idealistic
+- terrified
+- unprepared

--- a/content/playbooks/rookie.md
+++ b/content/playbooks/rookie.md
@@ -4,6 +4,13 @@ reasonToPlay: play as a young and idealistic recruit with an outside perspective
   the conflict, like Michel Ninorich from _08th MS Team_
 title: Rookie
 type: playbook
+startingActionDots:
+- action: rig
+  dots: 1
+- action: consort
+  dots: 1
+- action: scramble
+  dots: 1
 startingMove:
   name: Letters home
   description: When you roll Entanglements after a mission, you may narrate a

--- a/content/ships-and-crew/_index.md
+++ b/content/ships-and-crew/_index.md
@@ -1,0 +1,13 @@
+---
+title: Ships and Crew
+weight: 300
+
+---
+
+Use the crews from _Scum and Villainy_. There is, however, one major change that
+_Mobile Suits in the Black_ makes: all crews **start** with the **Personal
+vehicles** upgrade from the **Cerberus** crew.
+
+Additionally, the **Stardancer**'s **Problem Solvers** special ability is not
+considered a veteran crew advance. It's important that all characters have
+access to the **Helm** action more freely.

--- a/layouts/mobile-suit/single.html
+++ b/layouts/mobile-suit/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   <h5>{{ .Params.modelNumber }} {{ .Params.msName }}</h5>
-  Class: {{ .Params.msClass | title }} | <em><a href="{{ .Params.gundamWikiLink }}">See this mobile suit on the Gundam Wiki</a></em>
+  Class: {{ .Params.msClass | title }} | <em><a rel="noopener noreferrer nofollow" href="{{ .Params.gundamWikiLink }}">See this mobile suit on the Gundam Wiki</a></em>
 
   <div class="ms-portrait">
     <img src="{{ .Params.imageURL }}" alt="a picture of the {{ .Title }} mobile suit"/>

--- a/layouts/mobile-suit/single.html
+++ b/layouts/mobile-suit/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   <h5>{{ .Params.modelNumber }} {{ .Params.msName }}</h5>
-  Class: {{ .Params.msClass | title }} | <em><a rel="noopener noreferrer nofollow" href="{{ .Params.gundamWikiLink }}">See this mobile suit on the Gundam Wiki</a></em>
+  Class: {{ .Params.msClass | title }} | <em><a rel="noopener noreferrer nofollow" target="_blank" href="{{ .Params.gundamWikiLink }}">See this mobile suit on the Gundam Wiki</a></em>
 
   <div class="ms-portrait">
     <img src="{{ .Params.imageURL }}" alt="a picture of the {{ .Title }} mobile suit"/>

--- a/layouts/playbook/single.html
+++ b/layouts/playbook/single.html
@@ -5,7 +5,20 @@
 
   {{ .Content }}
 
-  <div class="playbook playbook-special-moves">
+  <div class="playbook playbook-section playbook-action-dots">
+    <h3>Starting actions</h3>
+    {{ if isset .Params "startingactiondots" }}
+      <table class="playbook playbook-action-dots-table"><tbody>
+      {{ range .Params.startingActionDots }}
+        <tr>
+          <th>{{ humanize .action }}</th><td>{{ .dots }}</td>
+        </tr>
+      {{ end }}
+      </tbody></table>
+    {{ end }}
+  </div>
+
+  <div class="playbook playbook-section playbook-special-moves">
     <h3>Special moves</h3>
 
     {{ if isset .Params "startingmove" }}

--- a/layouts/playbook/single.html
+++ b/layouts/playbook/single.html
@@ -5,9 +5,9 @@
 
   {{ .Content }}
 
+  {{ if isset .Params "startingactiondots" }}
   <div class="playbook playbook-section playbook-action-dots">
     <h3>Starting actions</h3>
-    {{ if isset .Params "startingactiondots" }}
       <table class="playbook playbook-action-dots-table"><tbody>
       {{ range .Params.startingActionDots }}
         <tr>
@@ -15,8 +15,8 @@
         </tr>
       {{ end }}
       </tbody></table>
-    {{ end }}
   </div>
+  {{ end }}
 
   <div class="playbook playbook-section playbook-special-moves">
     <h3>Special moves</h3>

--- a/layouts/playbook/single.html
+++ b/layouts/playbook/single.html
@@ -6,28 +6,29 @@
   {{ .Content }}
 
   {{ if isset .Params "startingactiondots" }}
-  <div class="playbook playbook-section playbook-action-dots">
-    <h3>Starting actions</h3>
-      <table class="playbook playbook-action-dots-table"><tbody>
-      {{ range .Params.startingActionDots }}
-        <tr>
-          <th>{{ humanize .action }}</th><td>{{ .dots }}</td>
-        </tr>
-      {{ end }}
-      </tbody></table>
-  </div>
+    <div class="playbook playbook-section playbook-action-dots">
+      <h3>Starting actions</h3>
+        <table class="playbook playbook-action-dots-table"><tbody>
+        {{ range .Params.startingActionDots }}
+          <tr>
+            <th>{{ humanize .action }}</th><td>{{ .dots }}</td>
+          </tr>
+        {{ end }}
+        </tbody></table>
+    </div>
   {{ end }}
 
-  <div class="playbook playbook-section playbook-special-moves">
-    <h3>Special moves</h3>
+  {{ if or ( isset .Params "specialmoves" ) ( isset .Params "startingmove" ) }}
+    <div class="playbook playbook-section playbook-special-moves">
+      <h3>Special moves</h3>
+        {{ if isset .Params "startingmove" }}
+          {{ $startingMoveName := print .Params.startingMove.name " (starting move)" }}
+          {{ partial "special-move.html" (dict "name" $startingMoveName "description" .Params.startingMove.description) }}
+        {{ end }}
 
-    {{ if isset .Params "startingmove" }}
-      {{ $startingMoveName := print .Params.startingMove.name " (starting move)" }}
-      {{ partial "special-move.html" (dict "name" $startingMoveName "description" .Params.startingMove.description) }}
-    {{ end }}
-
-  {{ range .Params.specialMoves }}
-    {{ partial "special-move.html" (dict "name" .name "description" .description) }}
-  {{ end  }}
-  </div><!-- end .playbook-special-moves -->
+      {{ range .Params.specialMoves }}
+        {{ partial "special-move.html" (dict "name" .name "description" .description) }}
+      {{ end  }}
+    </div><!-- end .playbook-special-moves -->
+  {{ end }}
 {{ end }}

--- a/playbook-scratch.md
+++ b/playbook-scratch.md
@@ -1,0 +1,29 @@
+- soldier (Karen Joshua, Sanders, Mu La Flaga, Emma Sheen)
+  - ace - combat specialist
+  - veteran - maintenance of team, maintenance of MS
+  - mechanic - maintenance of MS, maintenance of team
+- Commander (Shiro Amada, Bright Noa, Mu La Flaga)
+  - Actions: Command 2, Study 1
+  - **Hard choices**: before the start of a mission, you have to make a call. If
+      you have the crew attack just there, or at just that time, you'll have an
+      edge. Your crew has potency on their actions as long as the follow your
+      directives for the mission. But there's a cost... there's always a cost.
+      Choose one:
+      - Harm that your crew takes during this mission is 1 level higher than it
+          would normally be, because you've put them directly in the line of fire.
+      - The GM starts a 6-clock, which they will fill as the mission proceeds
+          (most likely on failed rolls). When it is full, the enemy's elite
+          reinforcements arrive. They outclass you, even with your tactical
+          edge.
+  - **Shrewd command**: You gain potency when you lead a group action.
+      Additionally, suffer 1 less stress for failed rolls.
+- cyber newtype (Four Murasame, Rosamia Badam, Marida Cruz, Stella, Sting, Rau
+    Le Creuset)
+- rookie/idealist (Michel Ninorich, Cagalli, Kira, Amuro, Kamille)
+
+Newtype moves (can be taken by any playbook, are not veteran advances):
+
+- push to meet significant person in NT space
+- sense rival behind obstacle
+-
+

--- a/sorensen_questions.md
+++ b/sorensen_questions.md
@@ -1,0 +1,5 @@
+# What is your game about?
+
+# How does the game do this?
+
+# How does the game reward/encourage this?


### PR DESCRIPTION
This PR:

- adds MS listings for the RMG-79 and AMX-004 Qubeley
- updates the playbook layout and archetype to include action ratings
- adds a Commander playbook
- adds action ratings to the Rookie playbook

it also adds a scratch sheet for working through the playbooks to be added (not to be published).